### PR TITLE
Fix: module rml2yarrrml not found in bin/generator.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Cannot find module rml2yarrrml when running yarrrml-generator (see [issue 106](https://github.com/RMLio/yarrrml-parser/issues/106))
+
 ## [1.2.1] - 2020-09-04
 
 ### Fixed
 - Fix docker build command in README (see [issue 91](https://github.com/RMLio/yarrrml-parser/issues/91))
 - Test example5 is invalid YARRRML (see [issue 93](https://github.com/RMLio/yarrrml-parser/issues/93))
 - Mapping TSV files (see [issue 95](https://github.com/RMLio/yarrrml-parser/issues/95))
-- Cannot find module rml2yarrrml when running yarrrml-generator (see [issue 106](https://github.com/RMLio/yarrrml-parser/issues/106))
 
 ### Changed
 - Update dev deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix docker build command in README (see [issue 91](https://github.com/RMLio/yarrrml-parser/issues/91))
 - Test example5 is invalid YARRRML (see [issue 93](https://github.com/RMLio/yarrrml-parser/issues/93))
 - Mapping TSV files (see [issue 95](https://github.com/RMLio/yarrrml-parser/issues/95))
+- Cannot find module rml2yarrrml when running yarrrml-generator (see [issue 106](https://github.com/RMLio/yarrrml-parser/issues/106))
 
 ### Changed
 - Update dev deps

--- a/bin/generator.js
+++ b/bin/generator.js
@@ -8,7 +8,7 @@
 const program = require('commander');
 const path = require('path');
 const fs = require('fs');
-const r2y = require('../lib/rml2yarrrml.js');
+const toYARRRML = require('../lib/yarrrml-generator.js');
 const pkginfo = require('pkginfo');
 const N3 = require('n3');
 const namespaces = require('prefix-ns').asMap();
@@ -46,7 +46,7 @@ if (!program.input) {
         console.error('There is a problem with your input.');
         process.exit(1);
       } else {
-        r2y(quads, prefixes).then(str => {
+        toYARRRML(quads, prefixes).then(str => {
           if (program.output) {
             if (!path.isAbsolute(program.output)) {
               program.output = path.join(process.cwd(), program.output);


### PR DESCRIPTION
Deprecated reference to `/lib/rml2yarrrml.js` in `/bin/parser.js`, module was renamed in https://github.com/RMLio/yarrrml-parser/commit/8280512eefb3e4fb17cae20507d53cdee42ec43e to `yarrrml-generator.js`.