### PR TITLE
Fix watcher issues with fs.watchFile() path and N3 writer addTriples()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Fix invalid input argument type array, in fs.watchFile()
+- Fix N3 addTriples() is not a function, in fs.watchFile()
+
 ## [1.2.1] - 2020-09-04
 
 ### Fixed

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -26,7 +26,7 @@ function watch(input, output, format) {
   }
 
   try {
-    fs.watchFile(input, convert);
+    fs.watchFile(inputFile, convert);
     convert();
 
     console.log(`Watching ${input} for changes...`);
@@ -59,7 +59,7 @@ function convert() {
       rdfs: namespaces.rdfs
     }
   });
-  writer.addTriples(rml);
+  writer.addQuads(rml);
   writer.end((error, result) => {
     if (!path.isAbsolute(outputFile)) {
       output = path.join(process.cwd(), outputFile);


### PR DESCRIPTION
Fix error:

> TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type
string or an instance of Buffer or URL. Received an instance of Array

Use `inputFile` which is the first file of the array `input`

---

Fix error:

> TypeError: writer.addTriples is not a function

Use method `addQuads()` instead