### PR TITLE
Remove static log variable from Logger class

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,8 @@
 const JSLogger = require('js-logger');
 JSLogger.useDefaults();
 
+var yarrrmlParser___Logger_log = [];
+
 class Logger {
 
     static trace(arg) { Logger._log(JSLogger.TRACE.name, arg) };
@@ -10,14 +12,12 @@ class Logger {
     static warn(arg) { Logger._log(JSLogger.WARN.name, arg) };
     static error(arg) { Logger._log(JSLogger.ERROR.name, arg) };
 
-    static logs = []
-
     /**
      * Get all logged messages
      * @return {array}
      */
     static getAll() {
-        return Logger.logs;
+        return yarrrmlParser___Logger_log;
     }
 
     /**
@@ -27,14 +27,14 @@ class Logger {
      */
     static has(level = '') {
         level = Logger._fixLevel(level);
-        return Logger.logs.some(l => l.level == level);
+        return yarrrmlParser___Logger_log.some(l => l.level == level);
     }
 
     /**
      * Clear all logs
      */
     static clear() {
-        Logger.logs = [];
+        yarrrmlParser___Logger_log = [];
     }
 
     /**
@@ -66,7 +66,7 @@ class Logger {
                 JSLogger.warn(`Undefined logging type "${level}" given. Message: ${arg.toString()}`);
                 break;
         }
-        Logger.logs.push({level, message: arg.toString()})
+        yarrrmlParser___Logger_log.push({level, message: arg.toString()})
     }
 
     static _fixLevel(level = '') {


### PR DESCRIPTION
Reason is that it is not in the ES5 standard and thus could not be used with some webpack scenarios.
With my change importing yarrrml-parser does not break the app.