### PR TITLE
fix: more instances of RML fetched namespace

### DIFF
--- a/lib/abstract-generator.js
+++ b/lib/abstract-generator.js
@@ -14,6 +14,7 @@ const Logger = require('./logger');
 namespaces.ql = 'http://semweb.mmlab.be/ns/ql#';
 namespaces.fnml = 'http://semweb.mmlab.be/ns/fnml#';
 namespaces.fno = 'https://w3id.org/function/ontology#';
+namespaces.rml = 'http://semweb.mmlab.be/ns/rml#';
 
 class AbstractGenerator {
 

--- a/lib/readable-rml.js
+++ b/lib/readable-rml.js
@@ -5,9 +5,9 @@
 const Logger = require('./logger');
 let N3 = require('n3');
 let Q = require('q');
-let prefixNS = require('prefix-ns');
+const namespaces = require('prefix-ns').asMap();
 
-let namespaces = prefixNS.asMap();
+namespaces.rml = 'http://semweb.mmlab.be/ns/rml#';
 
 let ignoredForBlankNodes = [
   namespaces.rr + 'class',

--- a/lib/rml-generator.js
+++ b/lib/rml-generator.js
@@ -17,6 +17,7 @@ namespaces.td = 'https://www.w3.org/2019/wot/td#'
 namespaces.wotsec = 'https://www.w3.org/2019/wot/security#'
 namespaces.hctl = 'https://www.w3.org/2019/wot/hypermedia#'
 namespaces.idsa = 'https://w3id.org/idsa/core/'
+namespaces.rml = 'http://semweb.mmlab.be/ns/rml#';
 namespaces.rmlt = 'http://semweb.mmlab.be/ns/rml-target#';
 namespaces.formats = 'http://www.w3.org/ns/formats/';
 namespaces.comp = 'http://semweb.mmlab.be/ns/rml-compression#';

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -13,6 +13,8 @@ const dataset = require('@graphy/memory.dataset.fast');
 const { Readable } = require('stream')
 const namespaces = require('prefix-ns').asMap();
 
+namespaces.rml = 'http://semweb.mmlab.be/ns/rml#';
+
 function compareY2RFiles(ymlPaths, ttlPath, options, cb) {
   const yamls = [];
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -11,6 +11,8 @@ const namespaces  = require('prefix-ns').asMap();
 const path        = require('path');
 const Logger = require('./logger');
 
+namespaces.rml = 'http://semweb.mmlab.be/ns/rml#';
+
 let inputFile;
 let outputFile;
 let initial = true;


### PR DESCRIPTION
After another CI fail where no TriplesMaps were found, I navigated through the code and saw that prefix.cc redefined `rml:`. 

https://github.com/RMLio/yarrrml-parser/commit/19aeab289b7580373c3b63bd017e97c5ec7a41c5 already fixed this in `bin/parser.js`; but as I was using `lib/rml-generator.js`, I created this PR to manually add the right rml namespace for all files where `namespaces.rml` was used. 

Fixes #195.