### PR TITLE
fix: all query whitespace replaced with single space

### DIFF
--- a/lib/rml-generator.js
+++ b/lib/rml-generator.js
@@ -529,7 +529,7 @@ class RMLGenerator extends AbstractGenerator {
           this.quads.push(quad(
             sSubject,
             namedNode(namespaces.rml + 'query'),
-            literal(source.query.replace(/\s+/g, ' ').trim())
+            literal(source.query.trim())
             ));
         }
 

--- a/lib/rml-generator.test.js
+++ b/lib/rml-generator.test.js
@@ -530,6 +530,15 @@ describe('YARRRML to RML', function () {
     });
   });
 
+  describe('YAML multiline strings', function () {
+    it('folds with chevron', function (done) {
+      work('yaml-multiline-string/block-scalar-folded/mapping.yarrr.yml', 'yaml-multiline-string/block-scalar-folded/mapping.rml.ttl', done, {includeMetadata: false});
+    });
+    
+    it('keeps literal with pipe', function (done) {
+      work('yaml-multiline-string/block-scalar-literal/mapping.yarrr.yml', 'yaml-multiline-string/block-scalar-literal/mapping.rml.ttl', done, {includeMetadata: false});
+    });
+  })
 });
 
 function doTestCase(testCaseID, options) {

--- a/test/spec/mapping-with-database-as-source/mapping.rml.ttl
+++ b/test/spec/mapping-with-database-as-source/mapping.rml.ttl
@@ -13,7 +13,7 @@
 
 :source_000 rdf:type rml:LogicalSource ;
 	rml:source :database_000 ;
-	rml:query "SELECT DEPTNO, DNAME, LOC, (SELECT COUNT(*) FROM EMP WHERE EMP.DEPTNO=DEPT.DEPTNO) AS STAFF FROM DEPT;" ;
+	rml:query "SELECT DEPTNO, DNAME, LOC,\n(SELECT COUNT(*) FROM EMP WHERE EMP.DEPTNO=DEPT.DEPTNO) AS STAFF\nFROM DEPT;" ;
 	rr:sqlVersion rr:SQL2008 ;
 	rml:referenceFormulation ql:CSV .
 

--- a/test/yaml-multiline-string/block-scalar-folded/mapping.rml.ttl
+++ b/test/yaml-multiline-string/block-scalar-folded/mapping.rml.ttl
@@ -1,0 +1,28 @@
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix : <http://mapping.example.com/> .
+
+:map_singleline_000 rml:logicalSource :source_000 ;
+	rdf:type rr:TriplesMap ;
+	rdfs:label "singleline" ;
+	rr:subjectMap :s_000 .
+
+:source_000 rdf:type rml:LogicalSource ;
+	rml:source :database_000 ;
+	rml:query "SELECT * FROM DEPT;" ;
+	rr:sqlVersion rr:SQL2008 ;
+	rml:referenceFormulation ql:CSV .
+
+:database_000 rdf:type d2rq:Database ;
+	d2rq:jdbcDSN "http://localhost/example" ;
+	d2rq:jdbcDriver "com.mysql.cj.jdbc.Driver" ;
+	d2rq:username "root" ;
+	d2rq:password "root" .
+
+:s_000 rdf:type rr:SubjectMap ;
+	rr:termType rr:BlankNode .
+

--- a/test/yaml-multiline-string/block-scalar-folded/mapping.yarrr.yml
+++ b/test/yaml-multiline-string/block-scalar-folded/mapping.yarrr.yml
@@ -1,0 +1,14 @@
+mapping:
+  singleline:
+    sources:
+      - access: http://localhost/example
+        type: mysql
+        credentials:
+          username: root
+          password: root
+        queryFormulation: sql2008
+        query: >
+          SELECT
+          *
+          FROM DEPT;
+        referenceFormulation: csv

--- a/test/yaml-multiline-string/block-scalar-literal/mapping.rml.ttl
+++ b/test/yaml-multiline-string/block-scalar-literal/mapping.rml.ttl
@@ -1,0 +1,28 @@
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix : <http://mapping.example.com/> .
+
+:map_multiline_000 rml:logicalSource :source_000 ;
+	rdf:type rr:TriplesMap ;
+	rdfs:label "multiline" ;
+	rr:subjectMap :s_000 .
+
+:source_000 rdf:type rml:LogicalSource ;
+	rml:source :database_000 ;
+	rml:query "SELECT\n*\nFROM DEPT;" ;
+	rr:sqlVersion rr:SQL2008 ;
+	rml:referenceFormulation ql:CSV .
+
+:database_000 rdf:type d2rq:Database ;
+	d2rq:jdbcDSN "http://localhost/example" ;
+	d2rq:jdbcDriver "com.mysql.cj.jdbc.Driver" ;
+	d2rq:username "root" ;
+	d2rq:password "root" .
+
+:s_000 rdf:type rr:SubjectMap ;
+	rr:termType rr:BlankNode .
+

--- a/test/yaml-multiline-string/block-scalar-literal/mapping.yarrr.yml
+++ b/test/yaml-multiline-string/block-scalar-literal/mapping.yarrr.yml
@@ -1,0 +1,14 @@
+mapping:
+  multiline:
+    sources:
+      - access: http://localhost/example
+        type: mysql
+        credentials:
+          username: root
+          password: root
+        queryFormulation: sql2008
+        query: |
+          SELECT
+          *
+          FROM DEPT;
+        referenceFormulation: csv


### PR DESCRIPTION
Fixes #214

Tests pass, with now fixed behaviour in test test/spec/mapping-with-database-as-source/mapping.rml.ttl